### PR TITLE
Update doc url.

### DIFF
--- a/certbot_s3front/installer.py
+++ b/certbot_s3front/installer.py
@@ -1,4 +1,7 @@
 """S3/CloudFront Let's Encrypt installer plugin."""
+
+from __future__ import print_function
+
 import os
 import sys
 import logging
@@ -49,7 +52,11 @@ class Installer(common.Plugin):
         Upload Certificate to IAM and assign it to the CloudFront distribution
         """
         if self.config.rsa_key_size > 2048:
-            print "The maximum public key size allowed for Cloudfront is 2048 (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/SecureConnections.html)\n Please, use --rsa_key_size 2048 or edit your cli.ini"
+            print(
+                "The maximum public key size allowed for Cloudfront is 2048 ("
+                "http://docs.aws.amazon.com/AmazonCloudFront/latest"
+                "/DeveloperGuide/SecureConnections.html)\n"
+                "Please, use --rsa_key_size 2048 or edit your cli.ini")
             sys.exit(1)
         client = boto3.client('iam')
         cf_client = boto3.client('cloudfront')

--- a/certbot_s3front/installer.py
+++ b/certbot_s3front/installer.py
@@ -54,8 +54,8 @@ class Installer(common.Plugin):
         if self.config.rsa_key_size > 2048:
             print(
                 "The maximum public key size allowed for Cloudfront is 2048 ("
-                "http://docs.aws.amazon.com/AmazonCloudFront/latest"
-                "/DeveloperGuide/SecureConnections.html)\n"
+                "https://docs.aws.amazon.com/AmazonCloudFront/latest"
+                "/DeveloperGuide/cnames-and-https-requirements.html)\n"
                 "Please, use --rsa_key_size 2048 or edit your cli.ini")
             sys.exit(1)
         client = boto3.client('iam')

--- a/certbot_s3front/installer.py
+++ b/certbot_s3front/installer.py
@@ -5,8 +5,6 @@ from __future__ import print_function
 import os
 import sys
 import logging
-import re
-import subprocess
 
 import zope.component
 import zope.interface
@@ -14,9 +12,6 @@ import zope.interface
 import boto3
 import botocore
 
-from acme import challenges
-
-from certbot import errors
 from certbot import interfaces
 from certbot.plugins import common
 


### PR DESCRIPTION
A simple update to the AWS documentation referencing the certificate limits.

Also did a tiny PEP8-compliant coding style fix and removed unused imports.