### PR TITLE
Instructions for Macs with Homebrew certbot install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The easiest way to install both the certbot client and the certbot-s3front plugi
   pip install certbot-s3front
   ```
 
-  #### Mac with Homebrew certbot?
+#### Mac with Homebrew certbot?
   Installed certbot certbot using Homebrew on Mac (as the official way to install on a Mac)? Find the full path to its python binary using this command:
 
   ```bash
@@ -39,7 +39,7 @@ The easiest way to install both the certbot client and the certbot-s3front plugi
   Alternatively, you can have a local set up for Python and we recommend a [virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/) and have both certbot and certbot-s3front installed via pip.
   You might also need to install `dialog`: `brew install dialog`.
 
-  #### Ubuntu?
+#### Ubuntu?
   If you are in Ubuntu you will need to install `pip` and other libraries first:
   ```
   apt-get install python-pip python-dev libffi-dev libssl-dev libxml2-dev libxslt1-dev libjpeg8-dev zlib1g-dev dialog

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The easiest way to install both the certbot client and the certbot-s3front plugi
   Then use the full path to the `pip` binary found in the same folder to install certbot-s3front.
   Note, you will need to re-install the plugin each time Homebrew will update certbot
 
-  #### Mac with pip certbot?
+#### Mac with pip certbot?
   Alternatively, you can have a local set up for Python and we recommend a [virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/) and have both certbot and certbot-s3front installed via pip.
   You might also need to install `dialog`: `brew install dialog`.
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,22 @@ The easiest way to install both the certbot client and the certbot-s3front plugi
   pip install certbot-s3front
   ```
 
-  If you are in Mac OS you will need a local set up for Python and we recommend a [virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/).
+  #### Mac with Homebrew certbot?
+  Installed certbot certbot using Homebrew on Mac (as the official way to install on a Mac)? Find the full path to its python binary using this command:
+
+  ```bash
+  cat $(which certbot) | head -1
+  ```
+
+  Then use the full path to the `pip` binary found in the same folder to install certbot-s3front.
+  Note, you will need to re-install the plugin each time Homebrew will update certbot
+
+  #### Mac with pip certbot?
+  Alternatively, you can have a local set up for Python and we recommend a [virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/) and have both certbot and certbot-s3front installed via pip.
   You might also need to install `dialog`: `brew install dialog`.
 
-  If you are in Ubuntu you will need to install `pip` and other libraries:
+  #### Ubuntu?
+  If you are in Ubuntu you will need to install `pip` and other libraries first:
   ```
   apt-get install python-pip python-dev libffi-dev libssl-dev libxml2-dev libxslt1-dev libjpeg8-dev zlib1g-dev dialog
   ```


### PR DESCRIPTION
The official recommended way to install certbot itself on a Mac is via Homebrew. But I had trouble installing certbot-s3front plugin in to work with my Homebrew install of certbot.

I found working instruction at [certbot-heroku plugin's readme](https://github.com/gboudreau/certbot-heroku/blob/master/README.md), so transplanting those instructions into this readme.