### PR TITLE
added missing ListServerCertificates permission

### DIFF
--- a/sample-aws-policy.json
+++ b/sample-aws-policy.json
@@ -7,7 +7,7 @@
                 "iam:UploadServerCertificate",
                 "iam:UpdateServerCertificate",
                 "iam:DeleteServerCertificate",
-		"iam:ListServerCertificates"
+                "iam:ListServerCertificates"
             ],
             "Resource": [
                 "*"

--- a/sample-aws-policy.json
+++ b/sample-aws-policy.json
@@ -6,7 +6,8 @@
             "Action": [
                 "iam:UploadServerCertificate",
                 "iam:UpdateServerCertificate",
-                "iam:DeleteServerCertificate"
+                "iam:DeleteServerCertificate",
+		"iam:ListServerCertificates"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
When using the certbot-s3front software I got a permission error on the iam:ListServerCertificates action. By adding this to the policy it worked fine.

Thought I share this with the others.