### PR TITLE
Add missing allowed IAM action to sample AWS policy file

### DIFF
--- a/sample-aws-policy.json
+++ b/sample-aws-policy.json
@@ -6,7 +6,8 @@
             "Action": [
                 "iam:UploadServerCertificate",
                 "iam:UpdateServerCertificate",
-                "iam:DeleteServerCertificate"
+                "iam:DeleteServerCertificate",
+                "iam:ListServerCertificates"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
I tried to run certbot-s3front today with the following script and using an IAM account with the policy described in `certbot-s3front/sample-aws-policy.json`.

```bash
#!/usr/bin/env sh

BASE_DIR=certbot-s3front
WORK_DIR=${BASE_DIR}/workspace
LOG_DIR=${BASE_DIR}/log
CONFIG_DIR=${BASE_DIR}/config

if [[ ! -d ${BASE_DIR} ]]; then
    mkdir ${BASE_DIR}
    mkdir ${WORK_DIR}
    mkdir ${CONFIG_DIR}
    mkdir ${LOG_DIR}
fi

AWS_ACCESS_KEY_ID="<id>" \
AWS_SECRET_ACCESS_KEY="<key>" \
certbot --agree-tos -a certbot-s3front:auth \
--certbot-s3front:auth-s3-bucket <name> \
--certbot-s3front:auth-s3-region <region> \
-i certbot-s3front:installer \
--certbot-s3front:installer-cf-distribution-id <id> \
-d <domain> \
--config-dir ${CONFIG_DIR} \
--logs-dir ${LOG_DIR} \
--work-dir ${WORK_DIR}

```

However I got the following error:
```
ClientError: An error occurred (AccessDenied) when calling the ListServerCertificates operation: User: arn:aws:iam::<id>:user/certbot is not authorized to perform: iam:ListServerCertificates on resource: arn:aws:iam::<id>:server-certificate/cloudfront/letsencrypt/
```

Easy enough, as the error pointed out, all I needed to do to fix the problem was to add the `iam:ListServerCertificates` action to the list of allowed actions in the user's policy file.

All that needs doing is adding that extra permission to the file which I've done in this PR.