### PR TITLE
Add AWS credentials as explicit arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ The easiest way to install both the certbot client and the certbot-s3front plugi
 To generate a certificate and install it in a CloudFront distribution:
 
 ```bash
+AWS_ACCESS_KEY_ID="REPLACE_WITH_YOUR_KEY" \
+AWS_SECRET_ACCESS_KEY="REPLACE_WITH_YOUR_SECRET" \
 certbot --agree-tos -a certbot-s3front:auth \
---certbot-s3front:auth-s3-access-key "REPLACE_WITH_YOUR_KEY" \
---certbot-s3front:auth-s3-secret-key "REPLACE_WITH_YOUR_SECRET" \
 --certbot-s3front:auth-s3-bucket REPLACE_WITH_YOUR_BUCKET_NAME \
 [ --certbot-s3front:auth-s3-region your-bucket-region-name ] #(the default is us-east-1, unless you want to set it to something else, you can delete this line) \
 [ --certbot-s3front:auth-s3-directory your-bucket-directory ] # (default is "") \

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ The easiest way to install both the certbot client and the certbot-s3front plugi
 To generate a certificate and install it in a CloudFront distribution:
 
 ```bash
-AWS_ACCESS_KEY_ID="REPLACE_WITH_YOUR_KEY" \
-AWS_SECRET_ACCESS_KEY="REPLACE_WITH_YOUR_SECRET" \
 certbot --agree-tos -a certbot-s3front:auth \
+--certbot-s3front:auth-s3-access-key "REPLACE_WITH_YOUR_KEY" \
+--certbot-s3front:auth-s3-secret-key "REPLACE_WITH_YOUR_SECRET" \
 --certbot-s3front:auth-s3-bucket REPLACE_WITH_YOUR_BUCKET_NAME \
 [ --certbot-s3front:auth-s3-region your-bucket-region-name ] #(the default is us-east-1, unless you want to set it to something else, you can delete this line) \
 [ --certbot-s3front:auth-s3-directory your-bucket-directory ] # (default is "") \

--- a/certbot_s3front/installer.py
+++ b/certbot_s3front/installer.py
@@ -28,6 +28,10 @@ class Installer(common.Plugin):
     def add_parser_arguments(cls, add):
         add("cf-distribution-id", default=os.getenv('CF_DISTRIBUTION_ID'),
             help="CloudFront distribution id")
+        add("s3-access-key", default=os.getenv('AWS_ACCESS_KEY_ID'),
+            help="Access key ID")
+        add("s3-secret-key", default=os.getenv('AWS_SECRET_ACCESS_KEY'),
+            help="Secret key ID")
 
     def __init__(self, *args, **kwargs):
         self.certificate_main_domain = None
@@ -60,7 +64,9 @@ class Installer(common.Plugin):
                 "/DeveloperGuide/cnames-and-https-requirements.html)\n"
                 "Please, use --rsa_key_size 2048 or edit your cli.ini")
             sys.exit(1)
-        client = boto3.client('iam')
+        client = boto3.client('iam',
+                aws_access_key_id=self.conf('s3-access-key'),
+                aws_secret_access_key=self.conf('s3-secret-key'))
 
         name = "le-%s" % domain
         body = open(cert_path).read()
@@ -99,8 +105,12 @@ class Installer(common.Plugin):
             # Nothing to save
             return
 
-        client = boto3.client('iam')
-        cf_client = boto3.client('cloudfront')
+        client = boto3.client('iam',
+                aws_access_key_id=self.conf('s3-access-key'),
+                aws_secret_access_key=self.conf('s3-secret-key'))
+        cf_client = boto3.client('cloudfront',
+                aws_access_key_id=self.conf('s3-access-key'),
+                aws_secret_access_key=self.conf('s3-secret-key'))
 
         # Update CloudFront config to use the new one
         cf_cfg = cf_client.get_distribution_config(Id=self.conf('cf-distribution-id'))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from distutils.core import setup
 from setuptools import find_packages
 
-version = '0.4.2'
+version = '0.5.0'
 
 install_requires = [
     'acme>=0.1.1',


### PR DESCRIPTION
Hi,

I recently lost my hard-drive and had to reinstall cert-bot and this plugin. After a bit of work it became apparent that "certbot-auto" which is apparently the new way of doing things doesn't play nice with environment variables so I threw together this change as a solution.

This might be useful to others; though it's very possible that there is an easier and better way to do this that I was unable to figure out.

Thanks