### PR TITLE
Docker enhancements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!docker-entrypoint.sh

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ certbot.log
 /*.pem
 .env
 env.list
+letsencrypt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM python:3.6-alpine
-ENTRYPOINT [ "certbot" ]
 
 VOLUME /etc/letsencrypt /var/lib/letsencrypt
 WORKDIR /opt/certbot
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 RUN apk add --no-cache --virtual .certbot-deps \
     libffi \
@@ -18,3 +20,6 @@ RUN apk add --no-cache --virtual .build-deps \
     libffi-dev \
     && pip install certbot-s3front \
     && apk del .build-deps
+
+
+ENTRYPOINT [ "/usr/local/bin/docker-entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Then export the environment variables to an `env.list` file:
 ```bash
 echo AWS_ACCESS_KEY_ID=YOUR_ID >> env.list
 echo AWS_SECRET_ACCESS_KEY=YOUR_KEY >> env.list
+echo AWS_S3_BUCKET=YOUR_S3_BUCKET_NAME >> env.list
+echo AWS_DISTRIBUTION_ID=YOUR_DISTRIBUTION_ID >> env.list
+echo DOMAIN=YOUR_DOMAIN >> env.list
+echo EMAIL=YOUR_EMAIL >> env.list
 ```
 
 And finally run the docker image:
@@ -91,11 +95,4 @@ docker run --rm --name lets-encrypt -it \
     -v ./letsencrypt/:/etc/letsencrypt \
     --env-file env.list \
     certbot-s3front \
-        --init \
-        --agree-tos \
-        -a certbot-s3front:auth \
-        -i certbot-s3front:installer \
-        --certbot-s3front:auth-s3-bucket <YOUR_AWS_S3_BUCKET> \
-        --certbot-s3front:installer-cf-distribution-id <YOUR_AWS_CLOUDFRONT_DISTRIBUTION_ID> \
-        -d <YOUR_DOMAIN>
 ```

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/local/bin/certbot -n --init --agree-tos -a certbot-s3front:auth -i certbot-s3front:installer --certbot-s3front:auth-s3-bucket $AWS_S3_BUCKET --certbot-s3front:installer-cf-distribution-id $AWS_DISTRIBUTION_ID --email $EMAIL -d $DOMAIN


### PR DESCRIPTION
Hi,

I created a docker-entrypoint which runs non interactively so the created image can be used without the whole certbot cmd line option list.

This way the generated docker image can be used to run periodically in orchestrators like kubernetes or nomad with only the needed environment variables to renew certificates.