### PR TITLE
Fix broken compatibility with urllib3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ RUN apk add --no-cache --virtual .build-deps \
     openssl-dev \
     musl-dev \
     libffi-dev \
+    && pip install urllib3==1.25.11 \
     && pip install certbot-s3front \
     && apk del .build-deps


### PR DESCRIPTION
This PR fixes the following error message:

```
pkg_resources.ContextualVersionConflict: (urllib3 1.26.1 (/usr/local/lib/python3.6/site-packages), Requirement.parse('urllib3<1.26,>=1.25.4; python_version != "3.4"'), {'botocore'})
```