### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ distribution. It may take a couple minutes to update.
 
 ### Automate renewal
 
-To automate the renewal process without prompts (for example, with a monthly cron), you can add the certbot parameters `--renew-by-default --text`
+To automate the renewal process without prompts (for example, with a monthly cron), you can add the certbot parameters `--non-interactive`
 
 
 ### Using with Docker


### PR DESCRIPTION
Don't ever, EVER bluntly add `--renew-by-default` to cronjobs! Certbot should be run twice a day and Certbot itself should determine if a certificate is up for renewal. There is absolutely no need to force this with a command line option. Also, Let's Encrypt recommends to renew only after 60 days, NOT every month.