### PR TITLE
Downgrade pyOpenSSL to 23.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apk add --no-cache --virtual .build-deps \
     openssl-dev \
     musl-dev \
     libffi-dev \
+    && pip install pyOpenSSL==23.1.1 \
     && pip install urllib3==1.25.11 \
     && pip install certbot-s3front \
     && apk del .build-deps


### PR DESCRIPTION
At this time, building the image installs `pyOpenSSL` version `23.2.0`.  At runtime, the following error is observed:

```
An unexpected error occurred:
ValueError: Invalid version. The only valid version for X509Req is 0.
```

With `23.1.1`, certbot works correctly

Credit: https://serverfault.com/a/1132637/412944