### PR TITLE
update to work with certbot 2.8.0 (requires different command-line args)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ To generate a certificate and install it in a CloudFront distribution:
 ```bash
 AWS_ACCESS_KEY_ID="REPLACE_WITH_YOUR_KEY" \
 AWS_SECRET_ACCESS_KEY="REPLACE_WITH_YOUR_SECRET" \
-certbot --agree-tos -a certbot-s3front:auth \
---certbot-s3front:auth-s3-bucket REPLACE_WITH_YOUR_BUCKET_NAME \
-[ --certbot-s3front:auth-s3-region your-bucket-region-name ] #(the default is us-east-1, unless you want to set it to something else, you can delete this line) \
-[ --certbot-s3front:auth-s3-directory your-bucket-directory ] # (default is "") \
--i certbot-s3front:installer \
---certbot-s3front:installer-cf-distribution-id REPLACE_WITH_YOUR_CF_DISTRIBUTION_ID \
+certbot --agree-tos -a s3front_auth \
+--s3front_auth-s3-bucket REPLACE_WITH_YOUR_BUCKET_NAME \
+[ --s3front_auth-s3-region your-bucket-region-name ] #(the default is us-east-1, unless you want to set it to something else, you can delete this line) \
+[ --s3front_auth-s3-directory your-bucket-directory ] # (default is "") \
+-i s3front_installer \
+--s3front_installer-cf-distribution-id REPLACE_WITH_YOUR_CF_DISTRIBUTION_ID \
 -d REPLACE_WITH_YOUR_DOMAIN
 ```
 

--- a/certbot_s3front/authenticator.py
+++ b/certbot_s3front/authenticator.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 @zope.interface.implementer(interfaces.IAuthenticator)
 @zope.interface.provider(interfaces.IPluginFactory)
-class Authenticator(common.Plugin):
+class Authenticator(common.Plugin, interfaces.Authenticator):
     description = "S3/CloudFront Authenticator"
 
     @classmethod

--- a/certbot_s3front/installer.py
+++ b/certbot_s3front/installer.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 @zope.interface.implementer(interfaces.IInstaller)
 @zope.interface.provider(interfaces.IPluginFactory)
-class Installer(common.Plugin):
+class Installer(common.Installer):
     description = "S3/CloudFront Installer"
 
     @classmethod

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/usr/local/bin/certbot -n --init --agree-tos -a certbot-s3front:auth -i certbot-s3front:installer --certbot-s3front:auth-s3-bucket $AWS_S3_BUCKET --certbot-s3front:installer-cf-distribution-id $AWS_DISTRIBUTION_ID --email $EMAIL -d $DOMAIN
+/usr/local/bin/certbot -n --init --agree-tos -a s3front_auth -i s3front_installer --s3front_auth-s3-bucket $AWS_S3_BUCKET --s3front_installer-cf-distribution-id $AWS_DISTRIBUTION_ID --email $EMAIL -d $DOMAIN

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ version = '0.4.2'
 
 install_requires = [
     'acme>=0.1.1',
-    'certbot>=0.9.3',
+    'certbot>=2.8.0',
     'PyOpenSSL',
     'setuptools',  # pkg_resources
     'zope.interface',
@@ -55,8 +55,8 @@ setup(
     keywords = ['certbot', 'cloudfront', 's3'],
     entry_points={
         'certbot.plugins': [
-            'auth = certbot_s3front.authenticator:Authenticator',
-            'installer = certbot_s3front.installer:Installer',
+            's3front_auth = certbot_s3front.authenticator:Authenticator',
+            's3front_installer = certbot_s3front.installer:Installer',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from distutils.core import setup
 from setuptools import find_packages
 
-version = '0.4.2'
+version = '0.4.3'
 
 install_requires = [
     'acme>=0.1.1',


### PR DESCRIPTION
the plugin no longer works with certbot when I installed it recently (2.8.0). I wasn't intimate with the plugin architecture
before now, but looking at the current code and documentation the plugin name is whatever the name specified in the 
package entry_points definition. Those names were "auth" and "installer". The name "auth" cannot work at all against current certbot because it breaks inside their (buggish) argument pre-parser which picks out "auth" as a verb instead of an argument to '-a'. Beyond that though since there's no longer a package-name qualifier attached "auth" and "installer" seem a bit too generic, so I prepended these with "s3front_". This does mean that the command-line args are broken for previous but I didn't think forcing the "package_name:" on the front of them was a great option either since it kind of infers/pretends that the plugin mechanism works the same as it did.

Aside from plugin naming the certbot internals also now filter plugins according to interfaces they implement so I needed to add that otherwise they get filtered out. Aside from that everything seems to still work great! Thanks for creating this very useful bit of software!