### PR TITLE
Refactor S3 authentication to remove ACLs and use bucket policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ To generate a certificate and install it in a CloudFront distribution:
 ```bash
 AWS_ACCESS_KEY_ID="REPLACE_WITH_YOUR_KEY" \
 AWS_SECRET_ACCESS_KEY="REPLACE_WITH_YOUR_SECRET" \
-certbot --agree-tos -a certbot-s3front:auth \
---certbot-s3front:auth-s3-bucket REPLACE_WITH_YOUR_BUCKET_NAME \
-[ --certbot-s3front:auth-s3-region your-bucket-region-name ] #(the default is us-east-1, unless you want to set it to something else, you can delete this line) \
-[ --certbot-s3front:auth-s3-directory your-bucket-directory ] # (default is "") \
--i certbot-s3front:installer \
---certbot-s3front:installer-cf-distribution-id REPLACE_WITH_YOUR_CF_DISTRIBUTION_ID \
+certbot --agree-tos -a s3front_auth \
+--s3front_auth-s3-bucket REPLACE_WITH_YOUR_BUCKET_NAME \
+[ --s3front_auth-s3-region your-bucket-region-name ] #(the default is us-east-1, unless you want to set it to something else, you can delete this line) \
+[ --s3front_auth-s3-directory your-bucket-directory ] # (default is "") \
+-i s3front_installer \
+--s3front_installer-cf-distribution-id REPLACE_WITH_YOUR_CF_DISTRIBUTION_ID \
 -d REPLACE_WITH_YOUR_DOMAIN
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ The easiest way to install both the certbot client and the certbot-s3front plugi
   ```
   And then run `pip install certbot-s3front`.
 
+#### Local?
+  **Note:** This is usefull in a case where a PR that addresses a bug is not yet merged to the master branch.
+  Clone the repository and fetch the relevent PR from the remote repository. Use the command `git fetch origin pull/<PR_NUMBER>/head:<BRANCH_NAME>`. Run the command `pip install -e .` to install the certbot s3 plugin using local files.
+
 ### How to use it
 
 To generate a certificate and install it in a CloudFront distribution:
@@ -63,6 +67,7 @@ certbot --agree-tos -a s3front_auth \
 Follow the screen prompts and you should end up with the certificate in your
 distribution. It may take a couple minutes to update.
 
+Alternatively you can run `script.sh` by replacing the placeholders with the correct values to automate the entire process.
 
 ### Automate renewal
 

--- a/certbot_s3front/authenticator.py
+++ b/certbot_s3front/authenticator.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 @zope.interface.implementer(interfaces.IAuthenticator)
 @zope.interface.provider(interfaces.IPluginFactory)
-class Authenticator(common.Plugin):
+class Authenticator(common.Plugin, interfaces.Authenticator):
     description = "S3/CloudFront Authenticator"
 
     @classmethod

--- a/certbot_s3front/authenticator.py
+++ b/certbot_s3front/authenticator.py
@@ -64,8 +64,7 @@ class Authenticator(common.Plugin, interfaces.Authenticator):
         s3 = boto3.resource('s3', region_name=self.conf('s3-region'))
 
         s3.Bucket(self.conf('s3-bucket')).put_object(Key=self._get_key(achall),
-                                                     Body=validation,
-                                                     ACL='public-read')
+                                                     Body=validation)
 
         if response.simple_verify(
                 achall.chall, achall.domain,

--- a/certbot_s3front/installer.py
+++ b/certbot_s3front/installer.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 @zope.interface.implementer(interfaces.IInstaller)
 @zope.interface.provider(interfaces.IPluginFactory)
-class Installer(common.Plugin):
+class Installer(common.Installer):
     description = "S3/CloudFront Installer"
 
     @classmethod

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/usr/local/bin/certbot -n --init --agree-tos -a certbot-s3front:auth -i certbot-s3front:installer --certbot-s3front:auth-s3-bucket $AWS_S3_BUCKET --certbot-s3front:installer-cf-distribution-id $AWS_DISTRIBUTION_ID --email $EMAIL -d $DOMAIN
+/usr/local/bin/certbot -n --init --agree-tos -a s3front_auth -i s3front_installer --s3front_auth-s3-bucket $AWS_S3_BUCKET --s3front_installer-cf-distribution-id $AWS_DISTRIBUTION_ID --email $EMAIL -d $DOMAIN

--- a/script.sh
+++ b/script.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Set AWS Credentials (Consider using environment variables instead of hardcoding)
+export AWS_ACCESS_KEY_ID=""
+export AWS_SECRET_ACCESS_KEY=""
+
+# Define required variables
+S3_BUCKET=""
+CF_DISTRIBUTION_ID=""
+DOMAIN=""
+S3_REGION=""  # Default is us-east-1, change if needed
+S3_DIRECTORY=""  # Default is root directory
+
+# Run Certbot with the S3/CloudFront plugin
+certbot --agree-tos -a s3front_auth \
+  --s3front_auth-s3-bucket "$S3_BUCKET" \
+  --s3front_auth-s3-region "$S3_REGION" \
+  --s3front_auth-s3-directory "$S3_DIRECTORY" \
+  -i s3front_installer \
+  --s3front_installer-cf-distribution-id "$CF_DISTRIBUTION_ID" \
+  -d "$DOMAIN"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ version = '0.4.2'
 
 install_requires = [
     'acme>=0.1.1',
-    'certbot>=0.9.3',
+    'certbot>=2.8.0',
     'PyOpenSSL',
     'setuptools',  # pkg_resources
     'zope.interface',
@@ -55,8 +55,8 @@ setup(
     keywords = ['certbot', 'cloudfront', 's3'],
     entry_points={
         'certbot.plugins': [
-            'auth = certbot_s3front.authenticator:Authenticator',
-            'installer = certbot_s3front.installer:Installer',
+            's3front_auth = certbot_s3front.authenticator:Authenticator',
+            's3front_installer = certbot_s3front.installer:Installer',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from distutils.core import setup
 from setuptools import find_packages
 
-version = '0.4.2'
+version = '0.4.3'
 
 install_requires = [
     'acme>=0.1.1',


### PR DESCRIPTION
AWS now enforces "Bucket Owner Enforced" mode, ACLs cause errors, and bucket policies are the recommended approach).